### PR TITLE
another

### DIFF
--- a/.private/gitlab.com/duo_agent/openclaw/README.md
+++ b/.private/gitlab.com/duo_agent/openclaw/README.md
@@ -1,0 +1,90 @@
+cloud.digital.ocean
+- Create an app
+-Choose a source
+-Configure app
+
+Resource settings
+
+openclaw
+Worker
+openclaw
+Docker build detected
+
+Info
+Edit
+Name
+openclaw
+Resource type
+Worker
+Source
+Service provider
+Git
+Repository
+digitalocean-labs/openclaw-appplatform
+Branch
+main
+Size
+Edit
+Instance size
+2 GB RAM / 1 Shared vCPU / 200 GB bandwidth
+Containers
+1
+Deployment settings
+Edit
+Build command
+No build command defined
+Run command
+No run command defined
+Environment variables
+Edit
+Keys
+Values
+GRADIENT_API_KEY
+Encrypted 
+OPENCLAW_GATEWAY_TOKEN
+Encrypted 
+STABLE_HOSTNAME
+openclaw
+ENABLE_NGROK
+false
+TAILSCALE_ENABLE
+false
+ENABLE_SPACES
+false
+ENABLE_UI
+false
+NGROK_AUTHTOKEN
+Encrypted 
+TS_AUTHKEY
+Encrypted 
+RESTIC_SPACES_ACCESS_KEY_ID
+Encrypted 
+RESTIC_SPACES_SECRET_ACCESS_KEY
+Encrypted 
+RESTIC_SPACES_ENDPOINT
+tor1.digitaloceanspaces.com
+RESTIC_SPACES_BUCKET
+openclaw-backup
+RESTIC_PASSWORD
+Encrypted 
+OPENCLAW_GATEWAY_TOKEN
+Encrypted 
+SSH_ENABLE
+false
+GITHUB_USERNAME
+No value
+
+# FINAL NAME
+ct3d
+cost: $25 a month.
+
+
+Created and deployed new app — this is where the fun begins.
+BUILDING
+Today at 1:26:55 AM
+james@gianotti.cloud
+james@gianotti.cloud
+View details
+
+
+https://githubuniverse.com/


### PR DESCRIPTION
# Install

RUN 
```
npm install -g pnpm
ENV PNPM_HOME="/home/openclaw/.local/share/pnpm"
ENV PATH="${PNPM_HOME}/bin:${PATH}"`
```

## Dockerfile

RUN npm install -g pnpm

ENV PNPM_HOME="/home/openclaw/.local/share/pnpm"
ENV PATH="${PNPM_HOME}/bin:${PATH}"

RUN set -eux \
  && mkdir -p "${PNPM_HOME}/bin" \
  && pnpm add -g "openclaw@${OPENCLAW_VERSION}"

## Mac

export PNPM_HOME="$HOME/.local/share/pnpm"
export PATH="$PNPM_HOME/bin:$PATH"

## Reload
RUN `source ~/.zshrc`

---

Inside the container, pnpm will look under /home/openclaw/.local/share/pnpm/bin, which matches this config.

2. What’s happening on your Mac
In the VS Code terminal you ran:

bash
ENV PNPM_HOME="/home/openclaw/.local/share/pnpm"
ENV PATH="${PNPM_HOME}/bin:${PATH}"
ENV is a Dockerfile instruction, not a shell builtin, so macOS just ran the /usr/bin/ENV program and printed your environment twice.

Then you correctly did:

bash
export PNPM_HOME="$HOME/.local/share/pnpm"
export PATH="$PNPM_HOME/bin:$PATH"
source ~/.zshrc
After that, your local PNPM_HOME became:

text
PNPM_HOME=/Users/james/Library/pnpm
which comes from pnpm’s own pnpm setup (it likes ~/Library/pnpm on macOS).

So right now:

In Docker: PNPM_HOME=/home/openclaw/.local/share/pnpm (correct for that user).

On your Mac: PNPM_HOME=/Users/james/Library/pnpm (correct for a local pnpm install).

These do not need to match; they’re two different environments.

3. What you should do locally
For your Mac shell, let pnpm use its default location:

In ~/.zshrc, keep something like:

bash
export PNPM_HOME="$HOME/Library/pnpm"
export PATH="$PNPM_HOME/bin:$PATH"
Then reload:

bash
source ~/.zshrc
Do not use /home/openclaw/... locally; that path only makes sense inside the Linux container as the openclaw user.

4. Next steps
For Docker builds: keep the Dockerfile block above and focus on any build log error from DigitalOcean (if it still fails, paste that error and we’ll adjust).

For your Mac: run pnpm -v in the VS Code terminal; if that works, your local PNPM_HOME/PATH are fine and unrelated to the container issue.

If you share the latest DigitalOcean build failure message, I can pinpoint whether pnpm or something else is now breaking the image.


